### PR TITLE
Bug 2 partial section border

### DIFF
--- a/src/components/About/cards/aboutCard.tsx
+++ b/src/components/About/cards/aboutCard.tsx
@@ -188,7 +188,7 @@ const AboutCard = () => {
   const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
 
-  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1350);
+  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
 
   const profileImg = useStaticQuery(graphql`

--- a/src/components/About/cards/barCard.tsx
+++ b/src/components/About/cards/barCard.tsx
@@ -140,7 +140,7 @@ const BarCard = ({ isActive }: BarCardProps) => {
   const aboveMobile = isAboveMobile ? isAboveMobile : false;
   const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
-  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1350);
+  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
   return (
     <BarCardContainer

--- a/src/components/About/cards/contactCard.tsx
+++ b/src/components/About/cards/contactCard.tsx
@@ -135,7 +135,7 @@ const ContactCard = ({}: ContactCardProps) => {
   const aboveMobile = isAboveMobile ? isAboveMobile : false;
   const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
-  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1350);
+  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
   return (
     <ContactCardContainer>

--- a/src/components/About/cards/donutCard.tsx
+++ b/src/components/About/cards/donutCard.tsx
@@ -99,7 +99,7 @@ const DonutCard = ({ isActive }: DonutCardProps) => {
   const aboveMobile = isAboveMobile ? isAboveMobile : false;
   const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
-  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1350);
+  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
   return (
     <DonutCardContainer

--- a/src/components/About/charts/donut.tsx
+++ b/src/components/About/charts/donut.tsx
@@ -182,7 +182,7 @@ const Donut = ({
 
   const { isWindowWidthAboveOrBetweenThreshold } = useDeviceContext();
 
-  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1350);
+  const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
 
   return (

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -10,7 +10,7 @@ import preventScroll from '../../utils/preventScroll';
 import { useIntroContext } from '../../contexts/introContext';
 
 type SharedHeaderProps = {
-  isMobile: boolean;
+  isSmall: boolean;
 };
 
 const MobileNavContainer = styled.div`
@@ -132,8 +132,8 @@ const HomeIconContainer = styled.header<SharedHeaderProps>`
   z-index: 100;
   width: 100%;
   height: 62px;
-  top: ${(props) => (props.isMobile ? '0' : '3.5%')};
-  left: ${(props) => (props.isMobile ? '0' : '2.5%')};
+  top: ${(props) => (props.isSmall ? '0' : '3.5%')};
+  left: ${(props) => (props.isSmall ? '0' : '2.5%')};
 `;
 
 type IconWrapperProps = SharedHeaderProps & {
@@ -147,9 +147,9 @@ const IconWrapper = styled.div<IconWrapperProps>`
   align-items: center;
   border: 2px solid ${theme.colors.BLUE_1};
   border-radius: 12.5px;
-  width: ${(props) => (props.isMobile ? '60px' : '75px')};
-  height: ${(props) => (props.isMobile ? '45px' : '55px')};
-  margin: ${(props) => (props.isMobile ? 'auto auto auto 10px' : '0 auto 0 0')};
+  width: ${(props) => (props.isSmall ? '60px' : '75px')};
+  height: ${(props) => (props.isSmall ? '45px' : '55px')};
+  margin: ${(props) => (props.isSmall ? 'auto auto auto 10px' : '0 auto 0 0')};
   cursor: pointer;
   opacity: ${({ hasSeenIntro }) => (hasSeenIntro ? '1' : '0')};
   transform: ${({ hasSeenIntro }) =>
@@ -186,27 +186,27 @@ const HomeIconLetter = styled(Paragraph)<IconLetterProps>`
 `;
 
 type IconProps = {
-  isMobile: boolean;
+  isSmall: boolean;
   hasSeenIntro: boolean;
 };
 
-const Icon = ({ isMobile, hasSeenIntro }: IconProps) => {
+const Icon = ({ isSmall, hasSeenIntro }: IconProps) => {
   const [isHoveringIcon, setIsHoveringIcon] = React.useState(false);
 
   const fill = isHoveringIcon ? theme.colors.ORANGE_2 : theme.colors.BLUE_1;
 
   return (
     <IconWrapper
-      isMobile={isMobile}
+      isSmall={isSmall}
       isHovering={isHoveringIcon}
       hasSeenIntro={hasSeenIntro}
       onMouseEnter={() => setIsHoveringIcon(true)}
       onMouseLeave={() => setIsHoveringIcon(false)}
     >
-      <HomeIconLetter isMobile={isMobile} color={fill}>
+      <HomeIconLetter isSmall={isSmall} color={fill}>
         L
       </HomeIconLetter>
-      <HomeIconLetter isMobile={isMobile} color={fill}>
+      <HomeIconLetter isSmall={isSmall} color={fill}>
         G
       </HomeIconLetter>
     </IconWrapper>
@@ -218,22 +218,20 @@ const Header = () => {
   const { hasSeenIntro } = useIntroContext();
   const { isWindowWidthAboveOrBetweenThreshold } = useDeviceContext();
 
-  const isAboveMobile = isWindowWidthAboveOrBetweenThreshold(
-    SCREEN_SIZES.MOBILE
-  );
-  const isMobile = !isAboveMobile;
+  const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
+  const isSmall = !isAboveSmall;
 
   React.useEffect(() => {
-    if (isAboveMobile) {
+    if (isAboveSmall) {
       setIsMenuOpen(false);
     }
-  }, [isAboveMobile]);
+  }, [isAboveSmall]);
 
   return (
-    <HomeIconContainer id="header" isMobile={isMobile}>
-      {isMobile ? (
+    <HomeIconContainer id="header" isSmall={isSmall}>
+      {isSmall ? (
         <MobileNavContainer>
-          <Icon isMobile={isMobile} hasSeenIntro={hasSeenIntro} />
+          <Icon isSmall={isSmall} hasSeenIntro={hasSeenIntro} />
           <Hamburger
             isMenuOpen={isMenuOpen}
             setIsMenuOpen={setIsMenuOpen}
@@ -349,7 +347,7 @@ const Header = () => {
           </MobileMenu>
         </MobileNavContainer>
       ) : (
-        <Icon isMobile={isMobile} hasSeenIntro={hasSeenIntro} />
+        <Icon isSmall={isSmall} hasSeenIntro={hasSeenIntro} />
       )}
     </HomeIconContainer>
   );

--- a/src/components/Links/siteLinks.tsx
+++ b/src/components/Links/siteLinks.tsx
@@ -8,6 +8,7 @@ const SiteLinksContainer = styled.div`
   position: fixed;
   bottom: 35%;
   right: 0;
+  z-index: 10;
 `;
 
 type TransformWrapperProps = {

--- a/src/components/Links/socialLinks.tsx
+++ b/src/components/Links/socialLinks.tsx
@@ -14,6 +14,7 @@ const LinksContainer = styled.div`
   position: fixed;
   bottom: 0;
   left: 0;
+  z-index: 10;
 `;
 
 type WrapperProps = {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -24,17 +24,14 @@ const Footer = styled.div`
 
 const Layout = ({ pageTitle, children }: Record<string, any>) => {
   const { isWindowWidthAboveOrBetweenThreshold } = useDeviceContext();
-  const isAboveMobile = isWindowWidthAboveOrBetweenThreshold(
-    SCREEN_SIZES.MOBILE
-  );
-  const isMobile = !isAboveMobile;
+  const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
   return (
     <>
       <Header />
       <Main id="main">
-        {isMobile ? null : <SocialLinks />}
+        {isAboveSmall ? <SocialLinks /> : null}
         {children}
-        {isMobile ? null : <SiteLinks />}
+        {isAboveSmall ? <SiteLinks /> : null}
         <Footer id="footer" role="contentinfo">
           <div className="footer-content">
             <small>copyright Logan Garay</small>

--- a/src/components/sections.ts
+++ b/src/components/sections.ts
@@ -6,6 +6,8 @@ export const Section = styled.section<SectionProps>`
   min-height: ${(props) => (props.height ? `${props.height}px` : '100vh')};
   color: white;
   border-bottom: 1px solid white; // testing
+  position: relative;
+  z-index: 1;
 `;
 
 export const SectionContent = styled.div.attrs<SectionContentProps>(
@@ -26,7 +28,7 @@ export const SectionContent = styled.div.attrs<SectionContentProps>(
 `;
 
 export const SectionTitleContainer = styled.div`
-  margin: 30px 0 60px 0;
+  margin: 20px 0 60px 0;
 `;
 
 export const SectionTitle = styled.h3`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,7 @@ const IndexPage = () => {
         <Introduction />
         <Skills />
         <Experience />
-        <Journey />
+        {/* <Journey /> */}
         <CarouselProvider>
           <About />
         </CarouselProvider>

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -21,48 +21,101 @@ const AboutMeTitle = styled(SectionTitle)`
   text-align: start;
 `;
 
-const TopLeftBorder = styled.div`
+type BorderProps = {
+  isAboveMobile?: boolean;
+  isAbove925?: boolean;
+};
+
+const TopLeftBorder = styled.div<BorderProps>`
   position: absolute;
   top: 5%;
   left: 7.5%;
-  height: 15%;
-  width: 10%;
   border-left: 1px solid ${theme.colors.ORANGE_1};
   border-top: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAbove925 }) => {
+    if (isAbove925) {
+      return `
+        height: 10%;
+        width: 5.5%;
+      `;
+    } else {
+      return `
+      height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
-const BottomLeftBorder = styled.div`
+const BottomLeftBorder = styled.div<BorderProps>`
   position: absolute;
   bottom: 1.5%;
   left: 7.5%;
-  height: 15%;
-  width: 10%;
   border-left: 1px solid ${theme.colors.ORANGE_1};
   border-bottom: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAbove925 }) => {
+    if (isAbove925) {
+      return `
+        height: 10%;
+        width: 5.5%;
+      `;
+    } else {
+      return `
+      height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
-const TopRightBorder = styled.div`
+const TopRightBorder = styled.div<BorderProps>`
   position: absolute;
   top: 5%;
   right: 7.5%;
-  height: 15%;
-  width: 10%;
   border-right: 1px solid ${theme.colors.ORANGE_1};
   border-top: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAbove925 }) => {
+    if (isAbove925) {
+      return `
+        height: 10%;
+        width: 5.5%;
+      `;
+    } else {
+      return `
+      height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
-const BottomRightBorder = styled.div`
+const BottomRightBorder = styled.div<BorderProps>`
   position: absolute;
   bottom: 1.5%;
   right: 7.5%;
-  height: 15%;
-  width: 10%;
   border-right: 1px solid ${theme.colors.ORANGE_1};
   border-bottom: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAbove925 }) => {
+    if (isAbove925) {
+      return `
+        height: 10%;
+        width: 5.5%;
+      `;
+    } else {
+      return `
+      height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
 const CarouselContainer = styled.div`
@@ -349,8 +402,8 @@ const About = () => {
     SCREEN_SIZES.MEDIUM
   );
   const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.LARGE);
-  const isAbove1350 = isWindowWidthAboveOrBetweenThreshold(1350);
-  const above1350 = isAbove1350 ? isAbove1350 : false;
+  const isAbove1450 = isWindowWidthAboveOrBetweenThreshold(1450);
+  const above1450 = isAbove1450 ? isAbove1450 : false;
   const isAbove925 = isWindowWidthAboveOrBetweenThreshold(925);
   const above925 = isAbove925 ? isAbove925 : false;
 
@@ -390,63 +443,66 @@ const About = () => {
       height={isMobile ? windowHeight : undefined}
       style={{ paddingBottom: 80 }}
     >
-      <TopLeftBorder />
-      <BottomLeftBorder />
-      <TopRightBorder />
-      <BottomRightBorder />
+      <TopLeftBorder isAbove925={isAbove925} isAboveMobile={isAboveMobile} />
+      <BottomLeftBorder isAbove925={isAbove925} isAboveMobile={isAboveMobile} />
+      <TopRightBorder isAbove925={isAbove925} isAboveMobile={isAboveMobile} />
+      <BottomRightBorder
+        isAbove925={isAbove925}
+        isAboveMobile={isAboveMobile}
+      />
       <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
         <SectionTitleContainer>
           <AboutMeTitle>05. About Me</AboutMeTitle>
         </SectionTitleContainer>
         {above925 ? (
           <CarouselContainer>
-            <CarouselWrapper isAboveLarge={above1350}>
+            <CarouselWrapper isAboveLarge={above1450}>
               <OverflowContainer>
                 <Carousel>
                   <NextItemClone
                     action={action}
                     isVisible={isAnimated}
-                    isAboveLarge={above1350}
+                    isAboveLarge={above1450}
                   >
                     <NextCloneElement />
                   </NextItemClone>
-                  <NextItem isVisible={!isAnimated} isAboveLarge={above1350}>
+                  <NextItem isVisible={!isAnimated} isAboveLarge={above1450}>
                     <NextElement />
                   </NextItem>
                   <AnimatedNextItem
                     action={action}
                     isVisible={isAnimated}
-                    isAboveLarge={above1350}
+                    isAboveLarge={above1450}
                   >
                     <AnimatedNextElement />
                   </AnimatedNextItem>
-                  <ActiveItem isVisible={!isAnimated} isAboveLarge={above1350}>
+                  <ActiveItem isVisible={!isAnimated} isAboveLarge={above1450}>
                     <ActiveElment isActive />
                   </ActiveItem>
                   <AnimatedActiveItem
                     action={action}
                     isVisible={isAnimated}
-                    isAboveLarge={above1350}
+                    isAboveLarge={above1450}
                   >
                     <AnimatedActiveElement />
                   </AnimatedActiveItem>
                   <PreviousItem
                     isVisible={!isAnimated}
-                    isAboveLarge={above1350}
+                    isAboveLarge={above1450}
                   >
                     <PrevElement />
                   </PreviousItem>
                   <AnimatedPreviousItem
                     action={action}
                     isVisible={isAnimated}
-                    isAboveLarge={above1350}
+                    isAboveLarge={above1450}
                   >
                     <AnimatedPrevElement />
                   </AnimatedPreviousItem>
                   <PreviousItemClone
                     action={action}
                     isVisible={isAnimated}
-                    isAboveLarge={above1350}
+                    isAboveLarge={above1450}
                   >
                     <PrevCloneElement />
                   </PreviousItemClone>

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -21,6 +21,50 @@ const AboutMeTitle = styled(SectionTitle)`
   text-align: start;
 `;
 
+const TopLeftBorder = styled.div`
+  position: absolute;
+  top: 5%;
+  left: 7.5%;
+  height: 15%;
+  width: 10%;
+  border-left: 1px solid ${theme.colors.ORANGE_1};
+  border-top: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
+const BottomLeftBorder = styled.div`
+  position: absolute;
+  bottom: 1.5%;
+  left: 7.5%;
+  height: 15%;
+  width: 10%;
+  border-left: 1px solid ${theme.colors.ORANGE_1};
+  border-bottom: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
+const TopRightBorder = styled.div`
+  position: absolute;
+  top: 5%;
+  right: 7.5%;
+  height: 15%;
+  width: 10%;
+  border-right: 1px solid ${theme.colors.ORANGE_1};
+  border-top: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
+const BottomRightBorder = styled.div`
+  position: absolute;
+  bottom: 1.5%;
+  right: 7.5%;
+  height: 15%;
+  width: 10%;
+  border-right: 1px solid ${theme.colors.ORANGE_1};
+  border-bottom: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
 const CarouselContainer = styled.div`
   height: 675px; // testing
 `;
@@ -346,6 +390,10 @@ const About = () => {
       height={isMobile ? windowHeight : undefined}
       style={{ paddingBottom: 80 }}
     >
+      <TopLeftBorder />
+      <BottomLeftBorder />
+      <TopRightBorder />
+      <BottomRightBorder />
       <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
         <SectionTitleContainer>
           <AboutMeTitle>05. About Me</AboutMeTitle>

--- a/src/sections/experience.tsx
+++ b/src/sections/experience.tsx
@@ -16,26 +16,37 @@ export type ExperiencesProps = SharedPageProps & {
   calculatedWidth?: number;
 };
 
+const BottomLeftBorder = styled.div`
+  position: absolute;
+  bottom: 10%;
+  left: 15%;
+  height: 35%;
+  width: 25%;
+  border-left: 1px solid ${theme.colors.ORANGE_1};
+  border-bottom: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
+const TopRightBorder = styled.div`
+  position: absolute;
+  top: 7.5%;
+  right: 10%;
+  height: 35%;
+  width: 25%;
+  border-right: 1px solid ${theme.colors.ORANGE_1};
+  border-top: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
 const ExperiencesContainer = styled.div<ExperiencesProps>`
   position: relative;
   margin-bottom: 10px;
   display: flex;
   flex-direction: column;
-  /* TODO  move this to the section and then just adjust how far down and left/right it goes */
-  &:after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 25%;
-    height: ${(props) => (props.shouldChangeFlexDirection ? '10%' : '25%')};
-    border-left: 1px solid ${theme.colors.ORANGE_1};
-    border-bottom: 1px solid ${theme.colors.ORANGE_1};
-  }
 `;
 
 const ExperiencesTitle = styled(SectionTitle)`
-  text-align: end;
+  text-align: start;
 `;
 
 const ExperiencesWrapper = styled.div<ExperiencesProps>`
@@ -79,6 +90,8 @@ const Experience = () => {
 
   return (
     <Section id="experience" height={isMobile ? windowHeight : undefined}>
+      <BottomLeftBorder />
+      <TopRightBorder />
       <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
         <ExperiencesContainer
           shouldChangeFlexDirection={shouldChangeFlexDirection}

--- a/src/sections/experience.tsx
+++ b/src/sections/experience.tsx
@@ -16,26 +16,83 @@ export type ExperiencesProps = SharedPageProps & {
   calculatedWidth?: number;
 };
 
-const BottomLeftBorder = styled.div`
+type BorderProps = {
+  isAbove925?: boolean;
+  isAboveMedium?: boolean;
+  isAboveLarge?: boolean;
+};
+
+const BottomLeftBorder = styled.div<BorderProps>`
   position: absolute;
   bottom: 10%;
   left: 15%;
-  height: 35%;
-  width: 25%;
   border-left: 1px solid ${theme.colors.ORANGE_1};
   border-bottom: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAboveMedium, isAbove925, isAboveLarge }) => {
+    if (isAboveLarge) {
+      return `
+        height: 35%;
+        width: 25%;
+      `;
+    } else if (isAboveMedium) {
+      return `
+        height: 20%;
+        width: 15%;
+        bottom: 20%;
+        left: 10%;
+      `;
+    } else if (isAbove925) {
+      return `
+        height: 20%;
+        width: 15%;
+        left: 7.5%;
+        bottom: 15%;
+      `;
+    } else {
+      return `
+        height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
-const TopRightBorder = styled.div`
+const TopRightBorder = styled.div<BorderProps>`
   position: absolute;
   top: 7.5%;
-  right: 10%;
-  height: 35%;
-  width: 25%;
+  right: 15%;
   border-right: 1px solid ${theme.colors.ORANGE_1};
   border-top: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAboveMedium, isAbove925, isAboveLarge }) => {
+    if (isAboveLarge) {
+      return `
+        height: 35%;
+        width: 25%;
+      `;
+    } else if (isAboveMedium) {
+      return `
+        height: 20%;
+        width: 15%;
+        top: 10%;
+        right: 10%;
+      `;
+    } else if (isAbove925) {
+      return `
+        height: 20%;
+        width: 15%;
+        right: 9%;
+      `;
+    } else {
+      return `
+        height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
 const ExperiencesContainer = styled.div<ExperiencesProps>`
@@ -68,6 +125,7 @@ const Experience = () => {
     SCREEN_SIZES.MOBILE
   );
   const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
+  const isAbove925 = isWindowWidthAboveOrBetweenThreshold(925);
   const isAboveMedium = isWindowWidthAboveOrBetweenThreshold(
     SCREEN_SIZES.MEDIUM
   );
@@ -90,8 +148,16 @@ const Experience = () => {
 
   return (
     <Section id="experience" height={isMobile ? windowHeight : undefined}>
-      <BottomLeftBorder />
-      <TopRightBorder />
+      <BottomLeftBorder
+        isAbove925={isAbove925}
+        isAboveMedium={isAboveMedium}
+        isAboveLarge={isAboveLarge}
+      />
+      <TopRightBorder
+        isAbove925={isAbove925}
+        isAboveMedium={isAboveMedium}
+        isAboveLarge={isAboveLarge}
+      />
       <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
         <ExperiencesContainer
           shouldChangeFlexDirection={shouldChangeFlexDirection}

--- a/src/sections/skills.tsx
+++ b/src/sections/skills.tsx
@@ -18,20 +18,29 @@ export type SkillsProps = {
   shouldChangeFlexDirection?: boolean;
 };
 
+const BottomLeftBorder = styled.div`
+  position: absolute;
+  bottom: 2.5%;
+  left: 7.5%;
+  height: 50%;
+  width: 1%;
+  border-left: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
+const TopRightBorder = styled.div`
+  position: absolute;
+  top: 2.5%;
+  right: 7.5%;
+  height: 50%;
+  width: 1%;
+  border-right: 1px solid ${theme.colors.ORANGE_1};
+  z-index: -1;
+`;
+
 const SkillsContainer = styled.div<SkillsProps>`
-  /* background: lightgrey; //testing */
   position: relative;
   margin-bottom: 10px;
-  &:after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 25%;
-    height: ${(props) => (props.shouldChangeFlexDirection ? '10%' : '25%')};
-    border-right: 1px solid ${theme.colors.ORANGE_1}; // testing
-    border-bottom: 1px solid ${theme.colors.ORANGE_1}; // testing
-  }
 `;
 
 const Skills = () => {
@@ -57,6 +66,8 @@ const Skills = () => {
 
   return (
     <Section id="skills" height={isMobile ? windowHeight : undefined}>
+      <BottomLeftBorder />
+      <TopRightBorder />
       <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
         <SkillsContainer shouldChangeFlexDirection={shouldChangeFlexDirection}>
           <SectionTitleContainer>

--- a/src/sections/skills.tsx
+++ b/src/sections/skills.tsx
@@ -18,24 +18,57 @@ export type SkillsProps = {
   shouldChangeFlexDirection?: boolean;
 };
 
-const BottomLeftBorder = styled.div`
+type BorderProps = {
+  isAbove925?: boolean;
+  isAboveLarge?: boolean;
+};
+
+const BottomLeftBorder = styled.div<BorderProps>`
   position: absolute;
   bottom: 2.5%;
-  left: 7.5%;
-  height: 50%;
-  width: 1%;
-  border-left: 1px solid ${theme.colors.ORANGE_1};
+  left: 8.5%;
   z-index: -1;
+  ${({ isAbove925 }) => {
+    if (isAbove925) {
+      return `
+      height: 45%;
+      width: 1%;
+      border-left: 1px solid ${theme.colors.ORANGE_1};
+      `;
+    } else {
+      return `
+        height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
-const TopRightBorder = styled.div`
+const TopRightBorder = styled.div<BorderProps>`
   position: absolute;
   top: 2.5%;
-  right: 7.5%;
-  height: 50%;
+  height: 45%;
   width: 1%;
   border-right: 1px solid ${theme.colors.ORANGE_1};
   z-index: -1;
+  ${({ isAbove925, isAboveLarge }) => {
+    if (isAboveLarge) {
+      return `
+        right: 8.5%;
+      `;
+    } else if (isAbove925) {
+      return `
+        right: 9.5%;
+      `;
+    } else {
+      return `
+        height: 0;
+        width: 0;
+        border: none;
+      `;
+    }
+  }}
 `;
 
 const SkillsContainer = styled.div<SkillsProps>`
@@ -50,6 +83,7 @@ const Skills = () => {
   const isAboveMobile = isWindowWidthAboveOrBetweenThreshold(
     SCREEN_SIZES.MOBILE
   );
+  const isAbove925 = isWindowWidthAboveOrBetweenThreshold(925);
   const isAboveMedium = isWindowWidthAboveOrBetweenThreshold(
     SCREEN_SIZES.MEDIUM
   );
@@ -66,8 +100,8 @@ const Skills = () => {
 
   return (
     <Section id="skills" height={isMobile ? windowHeight : undefined}>
-      <BottomLeftBorder />
-      <TopRightBorder />
+      <BottomLeftBorder isAbove925={isAbove925} isAboveLarge={isAboveLarge} />
+      <TopRightBorder isAbove925={isAbove925} isAboveLarge={isAboveLarge} />
       <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
         <SkillsContainer shouldChangeFlexDirection={shouldChangeFlexDirection}>
           <SectionTitleContainer>


### PR DESCRIPTION
This PR aims to address the issues reported in this [BUG](https://github.com/L-Garay/Portfolio/issues/7)
- make the border elements just absolutely positioned elements anchored against the section rather than `:after` psuedo elements
- change the design for each section's border(s)
- change breakpoints at which mobile menu is shown and site/social links are rendered
- change width value at which the carousel cards consider `large`