### PR TITLE
Migrate about me content to contentful

### DIFF
--- a/src/components/About/cards/aboutCard.tsx
+++ b/src/components/About/cards/aboutCard.tsx
@@ -153,7 +153,7 @@ const SmallParagraph = styled.p`
 
 const Link = styled.a.attrs({
   target: '_blank',
-  rel: 'noopener noreferrer',
+  rel: 'noopener noreferrer'
 })`
   color: ${theme.colors.BLUE_1};
   text-decoration: none;
@@ -191,15 +191,87 @@ const AboutCard = () => {
   const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
 
-  const profileImg = useStaticQuery(graphql`
-    {
-      file(relativePath: { eq: "squareColorPortrait.jpg" }) {
-        childImageSharp {
-          gatsbyImageData(placeholder: BLURRED)
+  const contentfulDonutChartQuery = graphql`
+    query {
+      contentfulAboutMeCards(
+        title: { eq: "You know that I know that you want to know about me" }
+      ) {
+        id
+        title
+        descriptions {
+          descriptions
+        }
+        profileImage {
+          title
+          description
+          gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
         }
       }
     }
-  `);
+  `;
+
+  const { contentfulAboutMeCards: contentfulContent } = useStaticQuery(
+    contentfulDonutChartQuery
+  );
+
+  const descriptionsArray =
+    contentfulContent.descriptions.descriptions.split('$$');
+
+  // TODO refactor the generation of these descriptions to be an abstracted function outside of this component
+  const IdahoStateLinkIndex = descriptionsArray[0].indexOf(
+    'Idaho State University'
+  );
+  const IdahoStateLinkString = descriptionsArray[0].slice(
+    IdahoStateLinkIndex,
+    IdahoStateLinkIndex + 22
+  );
+  const IdahoStateLink = (
+    <Link href="https://www.isu.edu/">{IdahoStateLinkString}</Link>
+  );
+
+  const IdahoStateDescription1 = descriptionsArray[0].slice(
+    0,
+    IdahoStateLinkIndex
+  );
+  const IdahoStateDescription2 = descriptionsArray[0].slice(
+    IdahoStateLinkIndex + 22
+  );
+  const IdahoStateDescription = () => {
+    return (
+      <p>
+        {IdahoStateDescription1}
+        {IdahoStateLink}
+        {IdahoStateDescription2}
+      </p>
+    );
+  };
+
+  const CodeworksLinkIndex = descriptionsArray[1].indexOf('Boise Codeworks');
+  const CodeworksLinkString = descriptionsArray[1].slice(
+    CodeworksLinkIndex,
+    CodeworksLinkIndex + 15
+  );
+  const CodeworksLink = (
+    <Link href="https://boisecodeworks.com/">{CodeworksLinkString}</Link>
+  );
+
+  const CodeworksDescription1 = descriptionsArray[1].slice(
+    0,
+    CodeworksLinkIndex
+  );
+  const CodeworksDescription2 = descriptionsArray[1].slice(
+    CodeworksLinkIndex + 15
+  );
+  const CodeworksDescription = () => {
+    return (
+      <p>
+        {CodeworksDescription1}
+        {CodeworksLink}
+        {CodeworksDescription2}
+      </p>
+    );
+  };
+
   return (
     <AboutCardContainer
       isAboveMobile={aboveMobile}
@@ -212,7 +284,7 @@ const AboutCard = () => {
           isAboveSmall={aboveSmall}
           isAboveLarge={aboveLarge}
         >
-          You know that I know that you want to know about me
+          {contentfulContent.title}
         </Title>
       </TitleContainer>
       <ContentContainer>
@@ -222,14 +294,10 @@ const AboutCard = () => {
             onMouseLeave={() => setIsHoveringImage(false)}
           >
             <GatsbyImage
-              image={profileImg.file.childImageSharp.gatsbyImageData}
+              image={contentfulContent.profileImage.gatsbyImageData}
               alt="black and white oval portrait of Logan Garay"
               imgStyle={{
-                width: isAboveLarge
-                  ? '200px'
-                  : isAboveSmall
-                  ? '165px'
-                  : '130px',
+                width: isAboveLarge ? '200px' : isAboveSmall ? '165px' : '130px'
               }}
               style={{
                 width: isAboveLarge
@@ -239,7 +307,7 @@ const AboutCard = () => {
                   : '130px',
                 borderRadius: '12.5px',
                 filter: isHoveringImage ? 'grayscale(0%)' : 'grayscale(100%)',
-                transition: 'filter 0.25s ease',
+                transition: 'filter 0.25s ease'
               }}
               loading="eager"
             />
@@ -255,38 +323,16 @@ const AboutCard = () => {
             isAboveSmall={aboveSmall}
             isAboveLarge={aboveLarge}
           >
-            <p>
-              These are always fun to write, am I right? Well I guess I'll tell
-              you a little about my background. I have a Bachelors of Science in
-              Psychology from{' '}
-              <Link href="https://www.isu.edu/">Idaho State University</Link>,
-              with a minor in Philosophy.
-            </p>
-            <p>
-              After I graduated in May 2019 I was left with a choice of what to
-              do with my life. My friend wanted to make video games and the
-              first step was to learn basic programming, and thanks to{' '}
-              <Link href="https://boisecodeworks.com/">Boise Codeworks</Link>{' '}
-              and 13 weeks later I was hooked. After that, well... the rest is
-              history.
-            </p>
+            <IdahoStateDescription />
+            <CodeworksDescription />
           </Description1>
           <Description2
             isAboveMobile={aboveMobile}
             isAboveSmall={aboveSmall}
             isAboveLarge={aboveLarge}
           >
-            <p>
-              When I'm not coding you can usually find me spending time with my
-              friends and two dogs, playing video games, lifting heavy weights
-              or watching some anime.
-            </p>
-            <p>
-              I have a passion for learning and am interested in all things
-              astronomy, anthropology, philosophy, history, psychology and of
-              course web development (to name a few); as I believe everyone
-              should strive to better understand the world around them.
-            </p>
+            <p>{descriptionsArray[2]}</p>
+            <p>{descriptionsArray[3]}</p>
           </Description2>
         </Row2>
         <Row3>

--- a/src/components/About/cards/barCard.tsx
+++ b/src/components/About/cards/barCard.tsx
@@ -5,6 +5,7 @@ import { BarChartFMConfig } from '../../../utils/configs/aboutConfigs';
 import SCREEN_SIZES from '../../../constants/screenSizes';
 import { useDeviceContext } from '../../../contexts/deviceContext';
 import theme from '../../../styles/theme';
+import { graphql, useStaticQuery } from 'gatsby';
 
 type BarCardProps = {
   isActive: boolean;
@@ -142,6 +143,26 @@ const BarCard = ({ isActive }: BarCardProps) => {
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
   const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
+
+  const contentfulDonutChartQuery = graphql`
+    query {
+      contentfulAboutMeCards(title: { eq: "You could say I like 'Soccer'" }) {
+        id
+        title
+        descriptions {
+          descriptions
+        }
+      }
+    }
+  `;
+
+  const { contentfulAboutMeCards: contentfulContent } = useStaticQuery(
+    contentfulDonutChartQuery
+  );
+
+  const descriptionsArray =
+    contentfulContent.descriptions.descriptions.split('$$');
+
   return (
     <BarCardContainer
       isAboveMobile={aboveMobile}
@@ -149,7 +170,7 @@ const BarCard = ({ isActive }: BarCardProps) => {
       isAboveLarge={aboveLarge}
     >
       <TitleContainer>
-        <Title>You could say I like 'Soccer'</Title>
+        <Title>{contentfulContent.title}</Title>
       </TitleContainer>
       <ContentContainer
         isAboveMobile={aboveMobile}
@@ -160,19 +181,8 @@ const BarCard = ({ isActive }: BarCardProps) => {
           <>
             <Column1>
               <Description>
-                <p>
-                  One of my major hobbies is soccer/football/fusbal. I regularly
-                  watch it and I also have two collegiate intramural
-                  championships under my belt, but I spend the most time
-                  managing virtual teams in the Football Manager series.
-                </p>
-                <p>
-                  The chart to the right shows just how much I enjoy playing the
-                  different games in the series. For context, the reason there
-                  are two outliers is that I left my computer on in school and
-                  would often leave the game on overnight. I am not THAT obessed
-                  with the game (is what I tell myself).
-                </p>
+                <p>{descriptionsArray[0]}</p>
+                <p>{descriptionsArray[1]}</p>
               </Description>
               <ChartKey>
                 <KeyItem>'FM' = Football Manager</KeyItem>
@@ -240,18 +250,8 @@ const BarCard = ({ isActive }: BarCardProps) => {
           <>
             <Row1>
               <Description>
-                <p>
-                  I regularly watch it, I have two collegiate intramural
-                  championships under my belt, but I spend the most time
-                  managing virtual teams in the Football Manager series.
-                </p>
-                <p>
-                  {' '}
-                  For context, the reason there are two outliers is that I left
-                  my computer on in school and would often leave the game on
-                  overnight. I am not THAT obessed with the game (is what I tell
-                  myself).
-                </p>
+                <p>{descriptionsArray[0]}</p>
+                <p> {descriptionsArray[1]}</p>
               </Description>
             </Row1>
             <Row2>

--- a/src/components/About/cards/contactCard.tsx
+++ b/src/components/About/cards/contactCard.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import theme from '../../../styles/theme';
 import SCREEN_SIZES from '../../../constants/screenSizes';
 import { useDeviceContext } from '../../../contexts/deviceContext';
+import { graphql, useStaticQuery } from 'gatsby';
 
 type ContactCardProps = {};
 
@@ -104,10 +105,10 @@ type ResumeButtonProps = {
   targetLink: string;
   targetType: string;
 };
-const ResmueButton = styled(ButtonAsLink).attrs<ResumeButtonProps>((props) => ({
+const ResmueButton = styled(ButtonAsLink).attrs<ResumeButtonProps>(props => ({
   href: props.targetLink,
   target: props.targetType,
-  download: props.targetType === '_self' ? true : undefined,
+  download: props.targetType === '_self' ? true : undefined
 }))<ResumeButtonProps>`
   text-align: center;
   cursor: pointer;
@@ -137,10 +138,30 @@ const ContactCard = ({}: ContactCardProps) => {
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
   const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
+
+  const contentfulDonutChartQuery = graphql`
+    query {
+      contentfulAboutMeCards(title: { eq: "Get in touch" }) {
+        id
+        title
+        descriptions {
+          descriptions
+        }
+      }
+    }
+  `;
+
+  const { contentfulAboutMeCards: contentfulContent } = useStaticQuery(
+    contentfulDonutChartQuery
+  );
+
+  const descriptionsArray =
+    contentfulContent.descriptions.descriptions.split('$$');
+
   return (
     <ContactCardContainer>
       <TitleContainer>
-        <Title>Get in touch</Title>
+        <Title>{contentfulContent.title}</Title>
       </TitleContainer>
       <ContentContainer
         isAboveMobile={aboveMobile}
@@ -149,17 +170,9 @@ const ContactCard = ({}: ContactCardProps) => {
       >
         <Row1>
           <Description>
-            <p>Thank you for checking out my site!</p>
-            <p>
-              Obviously I can't tell you everything about myself or my
-              experiences through here, so if you'd like to know more or have
-              any questions (or just want to say hello), please feel free to
-              reach out.
-            </p>
-            <p>
-              You can use any of the methods found below and I'll respond as
-              quickly as I can!{' '}
-            </p>
+            <p>{descriptionsArray[0]}</p>
+            <p>{descriptionsArray[1]} </p>
+            <p>{descriptionsArray[2]}</p>
           </Description>
         </Row1>
         <Row2>

--- a/src/components/About/cards/donutCard.tsx
+++ b/src/components/About/cards/donutCard.tsx
@@ -5,6 +5,7 @@ import { DonutConfig } from '../../../utils/configs/aboutConfigs';
 import SCREEN_SIZES from '../../../constants/screenSizes';
 import { useDeviceContext } from '../../../contexts/deviceContext';
 import theme from '../../../styles/theme';
+import { graphql, useStaticQuery } from 'gatsby';
 
 type DonutCardProps = {
   isActive: boolean;
@@ -101,6 +102,26 @@ const DonutCard = ({ isActive }: DonutCardProps) => {
   const aboveSmall = isAboveSmall ? isAboveSmall : false;
   const isAboveLarge = isWindowWidthAboveOrBetweenThreshold(1450);
   const aboveLarge = isAboveLarge ? isAboveLarge : false;
+
+  const contentfulDonutChartQuery = graphql`
+    query {
+      contentfulAboutMeCards(title: { eq: "Skills I'd like to learn" }) {
+        id
+        title
+        descriptions {
+          descriptions
+        }
+      }
+    }
+  `;
+
+  const { contentfulAboutMeCards: contentfulContent } = useStaticQuery(
+    contentfulDonutChartQuery
+  );
+
+  const descriptionsArray =
+    contentfulContent.descriptions.descriptions.split('$$');
+
   return (
     <DonutCardContainer
       isAboveMobile={aboveMobile}
@@ -108,7 +129,7 @@ const DonutCard = ({ isActive }: DonutCardProps) => {
       isAboveLarge={aboveLarge}
     >
       <TitleContainer>
-        <Title>Skills I'd like to learn</Title>
+        <Title>{contentfulContent.title}</Title>
       </TitleContainer>
       <ContentContainer>
         {aboveSmall ? (
@@ -120,15 +141,8 @@ const DonutCard = ({ isActive }: DonutCardProps) => {
             >
               <Donut {...DonutConfig[0]} isActive={isActive} />
               <Description>
-                <p>
-                  These are some of the different languages, frameworks and
-                  tools I'd like to try out and learn.
-                </p>
-                <p>
-                  The values are a totally not arbitrary calculation of my
-                  personal interest in the tool, likelihood of me using it soon
-                  and the benefit I think it would bring to my work.
-                </p>
+                <p>{descriptionsArray[0]}</p>
+                <p>{descriptionsArray[1]}</p>
               </Description>
               <Donut {...DonutConfig[1]} isActive={isActive} />
             </Row1>
@@ -151,15 +165,8 @@ const DonutCard = ({ isActive }: DonutCardProps) => {
               isAboveLarge={aboveLarge}
             >
               <Description>
-                <p>
-                  These are some of the different languages, frameworks and
-                  tools I'd like to try out and learn.
-                </p>
-                <p>
-                  The values are a totally not arbitrary calculation of my
-                  personal interest in the tool, likelihood of me using it soon
-                  and the benefit I think it would bring to my work.
-                </p>
+                <p>{descriptionsArray[0]}</p>
+                <p>{descriptionsArray[1]}</p>
               </Description>
             </Row1>
             <Row2


### PR DESCRIPTION
**Purpose:** migrate the content from the `About Me` section to Contentful
**Changes:** query for and use new contentful data within the different `About Me` components, need to add some logic for inserting `<Link />`s into some descriptions in the general/main `About Me` component
**Validation:** viewed each card/component and confirmed that the content is properly rendered and functionality is still there

**QUESTION:** something that might need to be investigated is the difference in how images (maybe other data) is returned/accessed depending on how it was added to the asset. I noticed that when trying to access the `profileImage` property for the general component, it kept saying that it couldn't query for the `title`, `description` and `gatsbyImageData` fields, but instead I needed to drill into `file` or `sys` and then `en_US` and then the property itself. That occurred when I uploaded media straight to the asset itself, instead of adding the media to Contentful and then referencing the media in the asset. Once I removed the media from the asset, and then re-added it (since it was already uploaded to Contentful at that point), I was able to drill directly into the image properties...