### PR TITLE
Migrate section titles fix mobile menu

### DIFF
--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -8,6 +8,7 @@ import SCREEN_SIZES from '../../constants/screenSizes';
 import { useDeviceContext } from '../../contexts/deviceContext';
 import preventScroll from '../../utils/preventScroll';
 import { useIntroContext } from '../../contexts/introContext';
+import { graphql, useStaticQuery } from 'gatsby';
 
 type SharedHeaderProps = {
   isSmall: boolean;
@@ -39,8 +40,8 @@ const MobileMenu = styled.div<MobileMenuProps>`
   top: 62px; // height of header
   right: 0;
   width: 100%;
-  width: ${(props) => (props.isMenuOpen ? '80%' : '0')};
-  opacity: ${(props) => (props.isMenuOpen ? '1' : '0')};
+  width: ${props => (props.isMenuOpen ? '80%' : '0')};
+  opacity: ${props => (props.isMenuOpen ? '1' : '0')};
   background: ${theme.colors.ORANGE_3};
   height: calc(100vh - 62px);
   transition: all 0.2s linear;
@@ -98,10 +99,10 @@ type MobileExternalLinkProps = {
 };
 
 const MobileExternalLinks = styled(ButtonAsLink).attrs<MobileExternalLinkProps>(
-  (props) => ({
+  props => ({
     href: props.targetLink,
     target: props.targetType,
-    download: props.targetType === '_self' ? true : false,
+    download: props.targetType === '_self' ? true : false
   })
 )<MobileExternalLinkProps>`
   text-align: center;
@@ -132,8 +133,8 @@ const HomeIconContainer = styled.header<SharedHeaderProps>`
   z-index: 100;
   width: 100%;
   height: 62px;
-  top: ${(props) => (props.isSmall ? '0' : '3.5%')};
-  left: ${(props) => (props.isSmall ? '0' : '2.5%')};
+  top: ${props => (props.isSmall ? '0' : '3.5%')};
+  left: ${props => (props.isSmall ? '0' : '2.5%')};
 `;
 
 type IconWrapperProps = SharedHeaderProps & {
@@ -147,9 +148,9 @@ const IconWrapper = styled.div<IconWrapperProps>`
   align-items: center;
   border: 2px solid ${theme.colors.BLUE_1};
   border-radius: 12.5px;
-  width: ${(props) => (props.isSmall ? '60px' : '75px')};
-  height: ${(props) => (props.isSmall ? '45px' : '55px')};
-  margin: ${(props) => (props.isSmall ? 'auto auto auto 10px' : '0 auto 0 0')};
+  width: ${props => (props.isSmall ? '60px' : '75px')};
+  height: ${props => (props.isSmall ? '45px' : '55px')};
+  margin: ${props => (props.isSmall ? 'auto auto auto 10px' : '0 auto 0 0')};
   cursor: pointer;
   opacity: ${({ hasSeenIntro }) => (hasSeenIntro ? '1' : '0')};
   transform: ${({ hasSeenIntro }) =>
@@ -159,7 +160,7 @@ const IconWrapper = styled.div<IconWrapperProps>`
   transition-timing-function: linear;
   transition-delay: 0.75s;
 
-  ${(props) => {
+  ${props => {
     if (props.isHovering) {
       return `
         &:hover,
@@ -178,9 +179,9 @@ type IconLetterProps = SharedHeaderProps & {
 };
 
 const HomeIconLetter = styled(Paragraph)<IconLetterProps>`
-  color: ${(props) => props.color};
+  color: ${props => props.color};
   transition: color 0.2s linear;
-  font-size: ${(props) => (props.isSmall ? '1.5rem' : '2rem')};
+  font-size: ${props => (props.isSmall ? '1.5rem' : '2rem')};
   padding: 0;
   font-weight: 900;
   display: inline-block;
@@ -235,6 +236,29 @@ const Header = () => {
     }
   }, [isAboveSmall]);
 
+  const contentfulDataQuery = graphql`
+    query {
+      allContentfulSectionTitles {
+        edges {
+          node {
+            id
+            shortTitle
+            number
+          }
+        }
+      }
+    }
+  `;
+
+  const {
+    allContentfulSectionTitles: { edges: contentfulSectionTitles }
+  } = useStaticQuery(contentfulDataQuery);
+
+  contentfulSectionTitles.sort(
+    (a: { node: { number: number } }, b: { node: { number: number } }) =>
+      a.node.number - b.node.number
+  );
+
   return (
     <HomeIconContainer id="header" isSmall={isSmall}>
       {isSmall ? (
@@ -250,66 +274,24 @@ const Header = () => {
             <MobileMenuContainer>
               {/* Site Links */}
               <MenuSection>
-                <MobileMenuLinkWrapper>
-                  <MenuLinkNumber>01.</MenuLinkNumber>
-                  <MobileMenuLink
-                    href="#introduction"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      preventScroll(false);
-                    }}
-                  >
-                    Intro
-                  </MobileMenuLink>
-                </MobileMenuLinkWrapper>
-                <MobileMenuLinkWrapper>
-                  <MenuLinkNumber>02.</MenuLinkNumber>
-                  <MobileMenuLink
-                    href="#skills"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      preventScroll(false);
-                    }}
-                  >
-                    Skills
-                  </MobileMenuLink>
-                </MobileMenuLinkWrapper>
-                <MobileMenuLinkWrapper>
-                  <MenuLinkNumber>03.</MenuLinkNumber>
-                  <MobileMenuLink
-                    href="#experience"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      preventScroll(false);
-                    }}
-                  >
-                    Experience
-                  </MobileMenuLink>
-                </MobileMenuLinkWrapper>
-                <MobileMenuLinkWrapper>
-                  <MenuLinkNumber>04.</MenuLinkNumber>
-                  <MobileMenuLink
-                    href="#journey"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      preventScroll(false);
-                    }}
-                  >
-                    Journey
-                  </MobileMenuLink>
-                </MobileMenuLinkWrapper>
-                <MobileMenuLinkWrapper>
-                  <MenuLinkNumber>05.</MenuLinkNumber>
-                  <MobileMenuLink
-                    href="#about"
-                    onClick={() => {
-                      setIsMenuOpen(false);
-                      preventScroll(false);
-                    }}
-                  >
-                    About
-                  </MobileMenuLink>
-                </MobileMenuLinkWrapper>
+                {contentfulSectionTitles.map((sectionData: any) => {
+                  const anchorLink = `#${sectionData.node.shortTitle.toLowerCase()}`;
+
+                  return (
+                    <MobileMenuLinkWrapper>
+                      <MenuLinkNumber>{sectionData.node.number}</MenuLinkNumber>
+                      <MobileMenuLink
+                        href={anchorLink}
+                        onClick={() => {
+                          setIsMenuOpen(false);
+                          preventScroll(false);
+                        }}
+                      >
+                        {sectionData.node.shortTitle}
+                      </MobileMenuLink>
+                    </MobileMenuLinkWrapper>
+                  );
+                })}
               </MenuSection>
 
               {/* My Stuff */}

--- a/src/components/Links/siteLinks.tsx
+++ b/src/components/Links/siteLinks.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Link, Paragraph } from '../shared';
 import theme from '../../styles/theme';
 import { useIntroContext } from '../../contexts/introContext';
+import { graphql, useStaticQuery } from 'gatsby';
 
 const SiteLinksContainer = styled.div`
   position: fixed;
@@ -46,7 +47,7 @@ const SiteLinkWrapper = styled.div<SiteLinkWrapperProps>`
   cursor: pointer;
   position: relative;
 
-  ${(props) => {
+  ${props => {
     if (props.isHovering) {
       return `
         border-radius: 0 12.5px 12.5px 0;
@@ -84,7 +85,7 @@ const SectionNameBanner = styled.div<SectionNameBannerProps>`
   align-items: center;
   border-radius: 12.5px 0 0 12.5px;
   border: none;
-  ${(props) => {
+  ${props => {
     if (props.isHovering) {
       return `
         width: 150px;
@@ -108,105 +109,92 @@ const SectionName = styled(Paragraph)`
   font-size: 1rem; // will change based on screen size
 `;
 
+const INITIAL_TRANSFORM_DELAY = 1.75;
+const TRANSFORM_DELAY_DECREMENT = 0.25;
+
 const SiteLinks = () => {
   const { hasSeenIntro } = useIntroContext();
 
-  const [isHoveringIntro, setIsHoveringIntro] = useState(false);
+  const [isHoveringIntroduction, setIsHoveringIntroduction] = useState(false);
   const [isHoveringSkills, setIsHoveringSkills] = useState(false);
-  const [isHoveringExperience, setIsHoveringExperience] = useState(false);
-  const [isHoveringJourney, setIsHoveringJourney] = useState(false);
+  const [isHoveringExperiences, setIsHoveringExperiences] = useState(false);
   const [isHoveringAbout, setIsHoveringAbout] = useState(false);
+
+  const contentfulDataQuery = graphql`
+    query {
+      allContentfulSectionTitles {
+        edges {
+          node {
+            id
+            shortTitle
+            number
+          }
+        }
+      }
+    }
+  `;
+
+  const {
+    allContentfulSectionTitles: { edges: contentfulSectionTitles }
+  } = useStaticQuery(contentfulDataQuery);
+
+  contentfulSectionTitles.sort(
+    (a: { node: { number: number } }, b: { node: { number: number } }) =>
+      a.node.number - b.node.number
+  );
 
   return (
     <SiteLinksContainer>
-      <TransformWrapper hasSeenIntro={hasSeenIntro} transformDelay={1.75}>
-        <SiteLinkWrapper
-          isHovering={isHoveringIntro}
-          onMouseEnter={() => {
-            setIsHoveringIntro(true);
-          }}
-          onMouseLeave={() => {
-            setIsHoveringIntro(false);
-          }}
-        >
-          <SiteLink href="#introduction">
-            01
-            <SectionNameBanner isHovering={isHoveringIntro}>
-              <SectionName>Introduction</SectionName>
-            </SectionNameBanner>
-          </SiteLink>
-        </SiteLinkWrapper>
-      </TransformWrapper>
-      <TransformWrapper hasSeenIntro={hasSeenIntro} transformDelay={1.5}>
-        <SiteLinkWrapper
-          isHovering={isHoveringSkills}
-          onMouseEnter={() => {
-            setIsHoveringSkills(true);
-          }}
-          onMouseLeave={() => {
-            setIsHoveringSkills(false);
-          }}
-        >
-          <SiteLink href="#skills">
-            02
-            <SectionNameBanner isHovering={isHoveringSkills}>
-              <SectionName>Skills</SectionName>
-            </SectionNameBanner>
-          </SiteLink>
-        </SiteLinkWrapper>
-      </TransformWrapper>
-      <TransformWrapper hasSeenIntro={hasSeenIntro} transformDelay={1.25}>
-        <SiteLinkWrapper
-          isHovering={isHoveringExperience}
-          onMouseEnter={() => {
-            setIsHoveringExperience(true);
-          }}
-          onMouseLeave={() => {
-            setIsHoveringExperience(false);
-          }}
-        >
-          <SiteLink href="#experience">
-            03
-            <SectionNameBanner isHovering={isHoveringExperience}>
-              <SectionName>Experience</SectionName>
-            </SectionNameBanner>
-          </SiteLink>
-        </SiteLinkWrapper>
-      </TransformWrapper>
-      {/* <TransformWrapper hasSeenIntro={hasSeenIntro} transformDelay={1.25}>
-        <SiteLinkWrapper
-          isHovering={isHoveringJourney}
-          onMouseEnter={() => {
-            setIsHoveringJourney(true);
-          }}
-          onMouseLeave={() => {
-            setIsHoveringJourney(false);
-          }}
-        >
-          <SiteLink href="#journey">04</SiteLink>
-          <SectionNameBanner isHovering={isHoveringJourney}>
-            <SectionName>Journey</SectionName>
-          </SectionNameBanner>
-        </SiteLinkWrapper>
-      </TransformWrapper> */}
-      <TransformWrapper hasSeenIntro={hasSeenIntro} transformDelay={1}>
-        <SiteLinkWrapper
-          isHovering={isHoveringAbout}
-          onMouseEnter={() => {
-            setIsHoveringAbout(true);
-          }}
-          onMouseLeave={() => {
-            setIsHoveringAbout(false);
-          }}
-        >
-          <SiteLink href="#about">
-            04
-            <SectionNameBanner isHovering={isHoveringAbout}>
-              <SectionName>About</SectionName>
-            </SectionNameBanner>
-          </SiteLink>
-        </SiteLinkWrapper>
-      </TransformWrapper>
+      {contentfulSectionTitles.map((sectionData: any, index: number) => {
+        const hoveringValue =
+          sectionData.node.shortTitle === 'Introduction'
+            ? isHoveringIntroduction
+            : sectionData.node.shortTitle === 'Skills'
+            ? isHoveringSkills
+            : sectionData.node.shortTitle === 'Experiences'
+            ? isHoveringExperiences
+            : isHoveringAbout;
+
+        const hoveringSetter =
+          sectionData.node.shortTitle === 'Introduction'
+            ? setIsHoveringIntroduction
+            : sectionData.node.shortTitle === 'Skills'
+            ? setIsHoveringSkills
+            : sectionData.node.shortTitle === 'Experiences'
+            ? setIsHoveringExperiences
+            : setIsHoveringAbout;
+
+        const transformDelay =
+          INITIAL_TRANSFORM_DELAY - TRANSFORM_DELAY_DECREMENT * index;
+
+        const anchorLink = `#${sectionData.node.shortTitle.toLowerCase()}`;
+
+        const noDecimalNumber = sectionData.node.number.slice(0, 2);
+
+        return (
+          <TransformWrapper
+            hasSeenIntro={hasSeenIntro}
+            transformDelay={transformDelay}
+          >
+            <SiteLinkWrapper
+              isHovering={hoveringValue}
+              onMouseEnter={() => {
+                hoveringSetter(true);
+              }}
+              onMouseLeave={() => {
+                hoveringSetter(false);
+              }}
+            >
+              <SiteLink href={anchorLink}>
+                {noDecimalNumber}
+                <SectionNameBanner isHovering={hoveringValue}>
+                  <SectionName>{sectionData.node.shortTitle}</SectionName>
+                </SectionNameBanner>
+              </SiteLink>
+            </SiteLinkWrapper>
+          </TransformWrapper>
+        );
+      })}
     </SiteLinksContainer>
   );
 };

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -4,7 +4,7 @@ import {
   Section,
   SectionContent,
   SectionTitleContainer,
-  SectionTitle,
+  SectionTitle
 } from '../components/sections';
 import { useDeviceContext } from '../contexts/deviceContext';
 import SCREEN_SIZES from '../constants/screenSizes';
@@ -14,9 +14,10 @@ import {
   AboutCard,
   BarCard,
   ContactCard,
-  DonutCard,
+  DonutCard
 } from '../components/About/cards';
 import { InViewProps } from 'src/constants/sharedTypes';
+import { graphql, useStaticQuery } from 'gatsby';
 
 const AboutMeTitle = styled(SectionTitle)<InViewProps>`
   text-align: start;
@@ -501,7 +502,7 @@ const About = React.forwardRef<HTMLDivElement, InViewProps>(
       animatedActiveElement,
       prevCloneElement,
       prevElement,
-      animatedPrevElement,
+      animatedPrevElement
     } = useCaourselContext();
 
     const NextCloneElement = nextCloneElement();
@@ -512,6 +513,20 @@ const About = React.forwardRef<HTMLDivElement, InViewProps>(
     const PrevCloneElement = prevCloneElement();
     const PrevElement = prevElement();
     const AnimatedPrevElement = animatedPrevElement();
+
+    const contentfulSectionTitles = graphql`
+      query {
+        contentfulSectionTitles(shortTitle: { eq: "About" }) {
+          id
+          longTitle
+          number
+        }
+      }
+    `;
+
+    const { contentfulSectionTitles: contentfulContent } = useStaticQuery(
+      contentfulSectionTitles
+    );
 
     return (
       <Section
@@ -543,7 +558,9 @@ const About = React.forwardRef<HTMLDivElement, InViewProps>(
         />
         <SectionContent isMobile={isMobile} calculatedWidth={calcluatedWidth}>
           <SectionTitleContainer>
-            <AboutMeTitle inView={inView}>04. About Me</AboutMeTitle>
+            <AboutMeTitle inView={inView}>
+              {contentfulContent.number} {contentfulContent.longTitle}
+            </AboutMeTitle>
           </SectionTitleContainer>
           {above925 ? (
             <CarouselContainer inView={inView}>

--- a/src/sections/experience.tsx
+++ b/src/sections/experience.tsx
@@ -4,13 +4,14 @@ import {
   Section,
   SectionContent,
   SectionTitle,
-  SectionTitleContainer,
+  SectionTitleContainer
 } from '../components/sections';
 import { useDeviceContext } from '../contexts/deviceContext';
 import SCREEN_SIZES from '../constants/screenSizes';
 import theme from '../styles/theme';
 import { InViewProps, SharedPageProps } from '../constants/sharedTypes';
 import { Details, Menu } from '../components/Experiences/';
+import { graphql, useStaticQuery } from 'gatsby';
 
 export type ExperiencesProps = SharedPageProps & {
   calculatedWidth?: number;
@@ -151,7 +152,7 @@ const StyledSectionTitle = styled(SectionTitle)<InViewProps>`
 
 const ExperiencesWrapper = styled.div<ExperiencesProps & InViewProps>`
   display: flex;
-  flex-direction: ${(props) => (props.isAboveSmall ? 'row' : 'column')};
+  flex-direction: ${props => (props.isAboveSmall ? 'row' : 'column')};
   justify-content: end;
   max-width: 820px;
   ${({ inView }) => {
@@ -207,9 +208,23 @@ const Experience = React.forwardRef<HTMLDivElement, InViewProps>(
     const flexWidthCutOff = SCREEN_SIZES.SMALL + 75;
     const shouldChangeFlexDirection = windowWidth < flexWidthCutOff;
 
+    const contentfulSectionTitles = graphql`
+      query {
+        contentfulSectionTitles(shortTitle: { eq: "Experiences" }) {
+          id
+          longTitle
+          number
+        }
+      }
+    `;
+
+    const { contentfulSectionTitles: contentfulContent } = useStaticQuery(
+      contentfulSectionTitles
+    );
+
     return (
       <Section
-        id="experience"
+        id="experiences"
         height={isMobile ? windowHeight : undefined}
         marginTop={isAboveSmall ? 225 : 0}
         ref={ref}
@@ -233,7 +248,7 @@ const Experience = React.forwardRef<HTMLDivElement, InViewProps>(
           >
             <SectionTitleContainer>
               <StyledSectionTitle inView={inView}>
-                03. My Experiences
+                {contentfulContent.number} {contentfulContent.longTitle}
               </StyledSectionTitle>
             </SectionTitleContainer>
 

--- a/src/sections/skills.tsx
+++ b/src/sections/skills.tsx
@@ -4,13 +4,14 @@ import {
   Section,
   SectionContent,
   SectionTitle,
-  SectionTitleContainer,
+  SectionTitleContainer
 } from '../components/sections';
 import { useDeviceContext } from '../contexts/deviceContext';
 import SCREEN_SIZES from '../constants/screenSizes';
 import theme from '../styles/theme';
 import { Languages, Qualities } from '../components/Skills/';
 import { InViewProps } from '../constants/sharedTypes';
+import { graphql, useStaticQuery } from 'gatsby';
 
 export type SkillsProps = {
   isAboveMobile?: boolean;
@@ -150,6 +151,20 @@ const Skills = React.forwardRef<HTMLDivElement, InViewProps>(
     const flexWidthCutOff = SCREEN_SIZES.SMALL + 75;
     const shouldChangeFlexDirection = windowWidth < flexWidthCutOff;
 
+    const contentfulDonutChartQuery = graphql`
+      query {
+        contentfulSectionTitles(shortTitle: { eq: "Skills" }) {
+          id
+          longTitle
+          number
+        }
+      }
+    `;
+
+    const { contentfulSectionTitles: contentfulContent } = useStaticQuery(
+      contentfulDonutChartQuery
+    );
+
     return (
       <Section
         id="skills"
@@ -173,7 +188,7 @@ const Skills = React.forwardRef<HTMLDivElement, InViewProps>(
             <SectionTitleContainer>
               <StyledSectionTitle inView={inView}>
                 {' '}
-                02. What I'm good at
+                {contentfulContent.number} {contentfulContent.longTitle}
               </StyledSectionTitle>
             </SectionTitleContainer>
 


### PR DESCRIPTION
**Purpose:** migrate the section titles and numbers to Contentful, use new data in sections, site links and mobile menu
**Changes:** migrate section title data to Contentful, refactor how site links and mobile menu links are rendered (now that we have an array of section data)
**Validation:** confirmed that each section has the proper title and number, site links still render properly and function, and mobile menu links render properly and still work