### PR TITLE
Anchor tag refresh fix

### DIFF
--- a/src/sections/introduction.tsx
+++ b/src/sections/introduction.tsx
@@ -71,9 +71,11 @@ const Introduction = () => {
   React.useEffect(() => {
     const anchorLinkTimeout = setTimeout(() => {
       const hash = window.location.hash;
-      const element = document.querySelector(hash);
-      if (hash && element && hasSeenIntro) {
-        element.scrollIntoView({ behavior: 'smooth' });
+      if (hash && hasSeenIntro) {
+        const element = document.querySelector(hash);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth' });
+        }
       }
     }, 2500);
 

--- a/src/sections/introduction.tsx
+++ b/src/sections/introduction.tsx
@@ -68,6 +68,20 @@ const Introduction = () => {
 
   const widthDeduction = isMobile ? 100 : 200;
 
+  React.useEffect(() => {
+    const anchorLinkTimeout = setTimeout(() => {
+      const hash = window.location.hash;
+      const element = document.querySelector(hash);
+      if (hash && element && hasSeenIntro) {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }
+    }, 2500);
+
+    return () => {
+      clearTimeout(anchorLinkTimeout);
+    };
+  }, [hasSeenIntro]);
+
   const contentfulGreetingQuery = graphql`
     query {
       contentfulIntroductionGreeting(intro: { eq: "My name is," }) {


### PR DESCRIPTION
Previously, when a user refreshed the page with an hash in the url, the animation would run but the user would stay at the top of the page. Similarly for when a user is linked to the site with a hash in the url, the has is ignored and the user stays at the top of the page. Ideally the user would be scrolled to the proper section based on the hash value.

This PR addresses that by waiting until the user has seen the intro, and taking into account the `Introduction` section's animations, before then checking for a hash in the url, and then scrolling to that section.

I have tested that this works, while also preserving the behavior where it properly stays at the top when no hash is present.