### PR TITLE
Add Contentful environment to Gatsby plugin config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -42,7 +42,8 @@ const config: GatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE_ID,
         accessToken: process.env.CONTENTFUL_CONTENT_API_TOKEN,
-        host: process.env.CONTENTFUL_HOST
+        host: process.env.CONTENTFUL_HOST,
+        environment: process.env.CONTENTFUL_ENVIRONMENT
       }
     },
     {


### PR DESCRIPTION
Specify the environment to allow control over which data/content to pull from