### PR TITLE
enable all preview options and fix preview hook arguments (live previews pt2)

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -4,14 +4,15 @@ import wrapWithIntroContext from './src/contexts/introContext';
 import { wrapRootWithProviders } from './src/utils/wrapRootWithProviders';
 import React, { ReactNode } from 'react';
 import { ContentfulLivePreviewProvider } from '@contentful/live-preview/react';
+import '@contentful/live-preview/style.css';
 
 const ContentfulLivePreview = ({ element }: { element: ReactNode }) => {
   return (
     <ContentfulLivePreviewProvider
       locale="en-US"
-      enableInspectorMode={false}
+      enableInspectorMode={true}
       enableLiveUpdates
-      debugMode={false}
+      debugMode={true}
     >
       {element}
     </ContentfulLivePreviewProvider>

--- a/src/components/Skills/qualities.tsx
+++ b/src/components/Skills/qualities.tsx
@@ -155,10 +155,7 @@ const Qualities = ({
 
   console.log('contentfulData: ', contentfulData);
 
-  const livePreviewData = useContentfulLiveUpdates({
-    contentfulData
-    // sys: { id: contentfulData.node.contentful_id }
-  });
+  const livePreviewData = useContentfulLiveUpdates(contentfulData);
 
   console.log('livePreviewData: ', livePreviewData);
 


### PR DESCRIPTION
Second attempt to get live previews working. Enable all live preview features, specifically the inspector. Fix how the arguments of the hook are passed in, don't pass in data as part of options argument.