### PR TITLE
move live preview provider to index file

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -20,8 +20,4 @@ const ContentfulLivePreview = ({ element }: { element: ReactNode }) => {
 };
 
 export const wrapRootElement: GatsbyBrowser['wrapRootElement'] =
-  wrapRootWithProviders([
-    wrapWithDeviceContext,
-    wrapWithIntroContext,
-    ContentfulLivePreview
-  ]);
+  wrapRootWithProviders([wrapWithDeviceContext, wrapWithIntroContext]);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,8 @@ import Experience from '../sections/experience';
 import Skills from '../sections/skills';
 import { CarouselProvider } from '../contexts/carouselContext';
 import AnimatedIntro from '../components/animatedIntro';
+import { ContentfulLivePreviewProvider } from '@contentful/live-preview/react';
+import '@contentful/live-preview/style.css';
 
 // Step 2: Define your component
 const IndexPage = () => {
@@ -19,32 +21,39 @@ const IndexPage = () => {
   const { ref: skillsRef, inView: skillsInView } = useInView({
     threshold: 0.5,
     delay: 250,
-    triggerOnce: true,
+    triggerOnce: true
   });
   const { ref: experienceRef, inView: experienceInView } = useInView({
     threshold: 0.5,
     delay: 250,
-    triggerOnce: true,
+    triggerOnce: true
   });
   const { ref: aboutRef, inView: aboutInView } = useInView({
     threshold: 0.5,
     delay: 250,
-    triggerOnce: true,
+    triggerOnce: true
   });
 
   return (
     <div style={{ position: 'relative' }}>
       <GlobalStyle />
       <AnimatedIntro />
-      <Layout>
-        <Introduction />
-        <Skills ref={skillsRef} inView={skillsInView} />
-        <Experience ref={experienceRef} inView={experienceInView} />
-        {/* <Journey /> */}
-        <CarouselProvider>
-          <About ref={aboutRef} inView={aboutInView} />
-        </CarouselProvider>
-      </Layout>
+      <ContentfulLivePreviewProvider
+        locale="en-US"
+        enableInspectorMode={true}
+        enableLiveUpdates={true}
+        debugMode={true}
+      >
+        <Layout>
+          <Introduction />
+          <Skills ref={skillsRef} inView={skillsInView} />
+          <Experience ref={experienceRef} inView={experienceInView} />
+          {/* <Journey /> */}
+          <CarouselProvider>
+            <About ref={aboutRef} inView={aboutInView} />
+          </CarouselProvider>
+        </Layout>
+      </ContentfulLivePreviewProvider>
     </div>
   );
 };


### PR DESCRIPTION
While the hook seems to be working locally, in the sense that it doesn't throw an error when it's used within the component. However, I don't think the updated data is ever getting to it, because the live preview does not update with the data when making edits in contentful. That is what leads me to think that the provider isn't properly wrapping the components when used within the `gatsby-browser.tsx` file.