### PR TITLE
attempt to get qualities preview working

### DIFF
--- a/src/components/Skills/qualities.tsx
+++ b/src/components/Skills/qualities.tsx
@@ -163,21 +163,21 @@ const Qualities = ({
 
   console.log('contentfulData: ', contentfulData);
 
-  const livePreviewData = useContentfulLiveUpdates(contentfulData);
+  const livePreviewData = useContentfulLiveUpdates({
+    contentfulData,
+    __typename: 'ContentfulSkillsQualities'
+  });
 
   console.log('livePreviewData: ', livePreviewData);
 
   const [data, setData] = useState(contentfulData);
 
   useEffect(() => {
+    console.log('preview data from in useEffect', livePreviewData);
     if (livePreviewData.contentfulData) {
       setData(livePreviewData.contentfulData);
     }
   }, [livePreviewData]);
-
-  // const data = livePreviewData.contentfulData
-  //   ? livePreviewData.contentfulData
-  //   : contentfulData;
 
   console.log('data: ', data);
 

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -539,8 +539,6 @@ const About = React.forwardRef<HTMLDivElement, InViewProps>(
       contentfulSectionTitles
     );
 
-    console.log('contentfulContent: ', contentfulContent);
-
     const [number, setNumber] = useState(contentfulContent.number);
     const [longTitle, setLongTitle] = useState(contentfulContent.longTitle);
 
@@ -561,8 +559,6 @@ const About = React.forwardRef<HTMLDivElement, InViewProps>(
       __typename: contentfulContent.__typename
     }) as LivePreviewData;
 
-    console.log('livePreviewData: ', livePreviewData);
-
     useEffect(() => {
       if (livePreviewData.number) {
         setNumber(livePreviewData.number);
@@ -571,13 +567,6 @@ const About = React.forwardRef<HTMLDivElement, InViewProps>(
         setLongTitle(livePreviewData.longTitle);
       }
     }, [livePreviewData]);
-
-    // const number = livePreviewData.contentfulContent.number
-    //   ? livePreviewData.contentfulContent.number
-    //   : contentfulContent.number;
-    // const longTitle = livePreviewData.contentfulContent.longTitle
-    //   ? livePreviewData.contentfulContent.longTitle
-    //   : contentfulContent.longTitle;
 
     return (
       <Section


### PR DESCRIPTION
Trying to implement the proper pattern within the qualities section. However, I am unsure of how to handle the `sys: { id: contentfulContent.contentful_id },` code that is used within the about section title code. As it references just one asset, whereas here we are pulling three distinct assets down