### PR TITLE
use multiple preview hooks for qualities

### DIFF
--- a/src/components/Skills/qualities.tsx
+++ b/src/components/Skills/qualities.tsx
@@ -164,20 +164,44 @@ const Qualities = ({
   const [data, setData] = useState(contentfulData);
   console.log('contentfulData: ', contentfulData);
 
-  const livePreviewData = useContentfulLiveUpdates({
-    contentfulData,
+  const livePreviewData1 = useContentfulLiveUpdates({
+    contentfulData: contentfulData[0],
     __typename: 'ContentfulSkillsQualities',
-    sys: { id: 'skillsDescriptions' }
+    sys: { id: contentfulData[0].contentful_id }
+  });
+  const livePreviewData2 = useContentfulLiveUpdates({
+    contentfulData: contentfulData[1],
+    __typename: 'ContentfulSkillsQualities',
+    sys: { id: contentfulData[1].contentful_id }
+  });
+  const livePreviewData3 = useContentfulLiveUpdates({
+    contentfulData: contentfulData[2],
+    __typename: 'ContentfulSkillsQualities',
+    sys: { id: contentfulData[2].contentful_id }
   });
 
-  console.log('livePreviewData: ', livePreviewData);
+  console.log(
+    'livePreviewData: ',
+    livePreviewData1,
+    livePreviewData2,
+    livePreviewData3
+  );
 
   useEffect(() => {
-    console.log('preview data from in useEffect', livePreviewData);
-    if (livePreviewData.contentfulData) {
-      setData(livePreviewData.contentfulData);
+    console.log(
+      'preview data from in useEffect',
+      livePreviewData1,
+      livePreviewData2,
+      livePreviewData3
+    );
+    if (livePreviewData1 || livePreviewData2 || livePreviewData3) {
+      setData([
+        livePreviewData1.contentfulData,
+        livePreviewData2.contentfulData,
+        livePreviewData3.contentfulData
+      ]);
     }
-  }, [livePreviewData]);
+  }, [livePreviewData1, livePreviewData2, livePreviewData3]);
 
   console.log('data: ', data);
 


### PR DESCRIPTION
passing in the generic `sys.contentType.sys.id` which is the same for each asset, use three separate live preview hooks for each distinct asset and then pass in that asset's `contentful_id`