### PR TITLE
Transition fixes

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,30 +5,32 @@ import { useInView, defaultFallbackInView } from 'react-intersection-observer';
 import Layout from '../components/layout';
 import Introduction from '../sections/introduction';
 import GlobalStyle from '..//styles/global';
-import Journey from '../sections/journey';
 import About from '../sections/about';
 import Experience from '../sections/experience';
 import Skills from '../sections/skills';
 import { CarouselProvider } from '../contexts/carouselContext';
+import { useDeviceContext } from '../contexts/deviceContext';
 import AnimatedIntro from '../components/animatedIntro';
+import SCREEN_SIZES from '../constants/screenSizes';
 
 // Step 2: Define your component
 const IndexPage = () => {
+  const { isWindowWidthAboveOrBetweenThreshold } = useDeviceContext();
+
+  const isAboveSmall = isWindowWidthAboveOrBetweenThreshold(SCREEN_SIZES.SMALL);
+
   defaultFallbackInView(true);
 
   const { ref: skillsRef, inView: skillsInView } = useInView({
-    threshold: 0.5,
-    delay: 250,
+    threshold: isAboveSmall ? 0.5 : 0.35, // may need to tweak this
     triggerOnce: true
   });
   const { ref: experienceRef, inView: experienceInView } = useInView({
     threshold: 0.5,
-    delay: 250,
     triggerOnce: true
   });
   const { ref: aboutRef, inView: aboutInView } = useInView({
-    threshold: 0.5,
-    delay: 250,
+    threshold: isAboveSmall ? 0.5 : 0.15, // may need to tweak this
     triggerOnce: true
   });
 
@@ -40,7 +42,6 @@ const IndexPage = () => {
         <Introduction />
         <Skills ref={skillsRef} inView={skillsInView} />
         <Experience ref={experienceRef} inView={experienceInView} />
-        {/* <Journey /> */}
         <CarouselProvider>
           <About ref={aboutRef} inView={aboutInView} />
         </CarouselProvider>

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -21,6 +21,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import { useContentfulLiveUpdates } from '@contentful/live-preview/react';
 import { useEffect, useState } from 'react';
 
+// #region STYLES
 const AboutMeTitle = styled(SectionTitle)<InViewProps>`
   text-align: start;
   ${({ inView }) => {
@@ -463,6 +464,7 @@ const StaticCardContainer = styled.div<InViewProps>`
 const StaticCardWrapper = styled.div`
   margin: 30px 0;
 `;
+// #endregion STYLES
 
 const About = React.forwardRef<HTMLDivElement, InViewProps>(
   ({ inView }, ref) => {


### PR DESCRIPTION
This PR addresses two separate but related issues:
- this [issue](https://github.com/L-Garay/Portfolio/issues/22) where the transition/animations prevent he `About Me` section from rendering on mobile
- this [issue](https://github.com/L-Garay/Portfolio/issues/27) where the section animation delays are too long

**Changes:** need to check for device width and then conditionally set the `threshold` hook option for `useInView` to allow for a smaller portion of the section to trigger the hook, remove the `delay` hook option for `useInView` to make it simpler to control the start of animations (controlled by each section individually)