### PR TITLE
use nonstandard delay times for lat two letters

### DIFF
--- a/src/utils/configs/animatedIntroConfig.tsx
+++ b/src/utils/configs/animatedIntroConfig.tsx
@@ -281,16 +281,16 @@ export const MEDIUM_WELCOME_DATA: WeclomeData[] = [
     id: 16,
     letter: 'L',
     delays: {
-      enter: 4.25, // NOTE no idea why these two values are acting different
-      leave: 6.25 // NOTE no idea why these two values are acting different
+      enter: 4.1, // NOTE no idea why these two values are acting different
+      leave: 6.1 // NOTE no idea why these two values are acting different
     }
   },
   {
     id: 17,
     letter: 'O',
     delays: {
-      enter: 4.5, // NOTE no idea why these two values are acting different
-      leave: 6.5 // NOTE no idea why these two values are acting different
+      enter: 4.35, // NOTE no idea why these two values are acting different
+      leave: 6.35 // NOTE no idea why these two values are acting different
     }
   }
   // {


### PR DESCRIPTION
This PR attempts to address the issue raised [here](https://github.com/L-Garay/Portfolio/issues/58).

It's crazy but there does seem to be a noticeable difference between a delay of `4.25` and `4.1` even though it's not even a full two-tenths of a second difference. At this point, without knowing the underlying reason as to **_WHY THE FUCK_** the two last values behave differently, I could play 'try to guess the perfect magic number that works the best across the different browsers', or I could enjoy my life.

In my mind, if there was a legit implementation issue with how I've setup my css and html I would expect all the letters to behave irratically/differently. The fact that it seems to **_ONLY_** affect the last two letters makes no sense to me. The delay of the animations works just fine up until the 4sec mark, then it just forgets what time is. 

**_UPDATE AS I'M TYPING THIS_**: I am an idiot and didn't check the mobile/small data set to see if it also behaves differently, and **_OF COURSE_** it does not. It works perfectly. So there is **_something_** with how the elements are rendered on larger screens? that is affecting the behavior of the animation delays? but only for the last two letters?